### PR TITLE
[Design] 맵 뷰 레이아웃 추가

### DIFF
--- a/Nav.xcodeproj/project.pbxproj
+++ b/Nav.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		262C17C0290D06F700450E54 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C17BF290D06F700450E54 /* Color+.swift */; };
 		262C17C2290D090C00450E54 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C17C1290D090C00450E54 /* Font+.swift */; };
 		262C17C6290E385E00450E54 /* Text+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C17C5290E385E00450E54 /* Text+.swift */; };
+		262C17CE290E9D4500450E54 /* Image+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C17CD290E9D4500450E54 /* Image+.swift */; };
 		26A1500B29083A1300BC7355 /* NavApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A1500A29083A1300BC7355 /* NavApp.swift */; };
 		26A1500D29083A1300BC7355 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A1500C29083A1300BC7355 /* ContentView.swift */; };
 		26A1500F29083A1400BC7355 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26A1500E29083A1400BC7355 /* Assets.xcassets */; };
@@ -21,6 +22,7 @@
 		262C17BF290D06F700450E54 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		262C17C1290D090C00450E54 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
 		262C17C5290E385E00450E54 /* Text+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+.swift"; sourceTree = "<group>"; };
+		262C17CD290E9D4500450E54 /* Image+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+.swift"; sourceTree = "<group>"; };
 		26A1500729083A1300BC7355 /* Nav.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nav.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		26A1500A29083A1300BC7355 /* NavApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavApp.swift; sourceTree = "<group>"; };
 		26A1500C29083A1300BC7355 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -63,6 +65,7 @@
 				26A1500C29083A1300BC7355 /* ContentView.swift */,
 				26A1501829083B7B00BC7355 /* MapView.swift */,
 				26A1500E29083A1400BC7355 /* Assets.xcassets */,
+				262C17CD290E9D4500450E54 /* Image+.swift */,
 				262C17C1290D090C00450E54 /* Font+.swift */,
 				262C17C5290E385E00450E54 /* Text+.swift */,
 				262C17BF290D06F700450E54 /* Color+.swift */,
@@ -153,6 +156,7 @@
 				262C17C2290D090C00450E54 /* Font+.swift in Sources */,
 				262C17C6290E385E00450E54 /* Text+.swift in Sources */,
 				262C17C0290D06F700450E54 /* Color+.swift in Sources */,
+				262C17CE290E9D4500450E54 /* Image+.swift in Sources */,
 				26A1501929083B7B00BC7355 /* MapView.swift in Sources */,
 				26A1500B29083A1300BC7355 /* NavApp.swift in Sources */,
 			);

--- a/Nav/Image+.swift
+++ b/Nav/Image+.swift
@@ -1,0 +1,31 @@
+//
+//  Image+.swift
+//  Nav
+//
+//  Created by 김민택 on 2022/10/30.
+//
+
+import SwiftUI
+
+extension Image {
+    func circleButton(iconColor: Color, iconWidth: CGFloat, iconHeight: CGFloat, buttonColor: Color, buttonSize: CGFloat, shadowColor: Color = Color(.sRGBLinear, white: 0, opacity: 0.33), shadowRadius: CGFloat = 0, shadowX: CGFloat = 0, shadowY: CGFloat = 0) -> some View {
+        var iconSize: CGFloat
+        
+        if iconWidth >= iconHeight {
+            iconSize = iconHeight
+        } else {
+            iconSize = iconWidth
+        }
+        
+        return self
+            .resizable()
+            .frame(width: iconWidth, height: iconHeight)
+            .foregroundColor(iconColor)
+            .padding((buttonSize - iconSize) / 2)
+            .background(
+                Circle()
+                    .fill(buttonColor)
+                    .shadow(color: shadowColor, radius: shadowRadius, x: shadowX, y: shadowY)
+            )
+    }
+}

--- a/Nav/MapView.swift
+++ b/Nav/MapView.swift
@@ -34,6 +34,7 @@ struct MapView: View {
                                 shadowRadius: 4,
                                 shadowY: 4
                             )
+                            .shadow(radius: 4, y: 4)
                     }
                     
                     Button(action: {}) {
@@ -47,6 +48,7 @@ struct MapView: View {
                                 shadowRadius: 4,
                                 shadowY: 4
                             )
+                            .shadow(radius: 4, y: 4)
                     }
                     
                     Spacer()
@@ -62,6 +64,7 @@ struct MapView: View {
                                 shadowRadius: 4,
                                 shadowY: 4
                             )
+                            .shadow(radius: 4, y: 4)
                     }
                 }
                 .padding(.trailing, 16)

--- a/Nav/MapView.swift
+++ b/Nav/MapView.swift
@@ -25,43 +25,43 @@ struct MapView: View {
                 VStack {
                     Button(action: {}) {
                         Image(systemName: "gearshape")
-                            .resizable()
-                            .frame(width: 20, height: 20)
-                            .foregroundColor(.white)
-                            .frame(width: 50, height: 50)
-                            .background(
-                                Circle()
-                                    .fill(.red)
+                            .circleButton(
+                                iconColor: .navWhite,
+                                iconWidth: 20,
+                                iconHeight: 20,
+                                buttonColor: .primary,
+                                buttonSize: 50,
+                                shadowRadius: 4,
+                                shadowY: 4
                             )
-                            .shadow(radius: 4, y: 4)
                     }
                     
                     Button(action: {}) {
                         Image(systemName: "list.bullet")
-                            .resizable()
-                            .frame(width: 20, height: 14.5)
-                            .foregroundColor(.white)
-                            .frame(width: 50, height: 50)
-                            .background(
-                                Circle()
-                                    .fill(.red)
+                            .circleButton(
+                                iconColor: .navWhite,
+                                iconWidth: 20,
+                                iconHeight: 14.5,
+                                buttonColor: .primary,
+                                buttonSize: 50,
+                                shadowRadius: 4,
+                                shadowY: 4
                             )
-                            .shadow(radius: 4, y: 4)
                     }
                     
                     Spacer()
                     
                     Button(action: {}) {
                         Image(systemName: "plus")
-                            .resizable()
-                            .frame(width: 17, height: 16)
-                            .foregroundColor(.white)
-                            .frame(width: 50, height: 50)
-                            .background(
-                                Circle()
-                                    .fill(.red)
+                            .circleButton(
+                                iconColor: .navWhite,
+                                iconWidth: 17,
+                                iconHeight: 16,
+                                buttonColor: .primary,
+                                buttonSize: 50,
+                                shadowRadius: 4,
+                                shadowY: 4
                             )
-                            .shadow(radius: 4, y: 4)
                     }
                 }
                 .padding(.trailing, 16)

--- a/Nav/MapView.swift
+++ b/Nav/MapView.swift
@@ -15,8 +15,61 @@ struct MapView: View {
 
     
     var body: some View {
-        Map(coordinateRegion: $region)
-            .ignoresSafeArea()
+        ZStack {
+            Map(coordinateRegion: $region)
+                .ignoresSafeArea()
+            
+            HStack {
+                Spacer()
+                
+                VStack {
+                    Button(action: {}) {
+                        Image(systemName: "gearshape")
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                            .foregroundColor(.white)
+                            .background(
+                                Circle()
+                                    .fill(.red)
+                                    .frame(width: 50, height: 50)
+                            )
+                    }
+                    .frame(width: 50, height: 50)
+                    .shadow(radius: 4, y: 4)
+                    
+                    Button(action: {}) {
+                        Image(systemName: "list.bullet")
+                            .resizable()
+                            .frame(width: 20, height: 14.5)
+                            .foregroundColor(.white)
+                            .background(
+                                Circle()
+                                    .fill(.red)
+                                    .frame(width: 50, height: 50)
+                            )
+                    }
+                    .frame(width: 50, height: 50)
+                    .shadow(radius: 4, y: 4)
+                    
+                    Spacer()
+                    
+                    Button(action: {}) {
+                        Image(systemName: "plus")
+                            .resizable()
+                            .frame(width: 17, height: 16)
+                            .foregroundColor(.white)
+                            .background(
+                                Circle()
+                                    .fill(.red)
+                                    .frame(width: 50, height: 50)
+                            )
+                    }
+                    .frame(width: 50, height: 50)
+                    .shadow(radius: 4, y: 4)
+                }
+                .padding(.trailing, 16)
+            }
+        }
     }
 }
 

--- a/Nav/MapView.swift
+++ b/Nav/MapView.swift
@@ -28,28 +28,26 @@ struct MapView: View {
                             .resizable()
                             .frame(width: 20, height: 20)
                             .foregroundColor(.white)
+                            .frame(width: 50, height: 50)
                             .background(
                                 Circle()
                                     .fill(.red)
-                                    .frame(width: 50, height: 50)
                             )
+                            .shadow(radius: 4, y: 4)
                     }
-                    .frame(width: 50, height: 50)
-                    .shadow(radius: 4, y: 4)
                     
                     Button(action: {}) {
                         Image(systemName: "list.bullet")
                             .resizable()
                             .frame(width: 20, height: 14.5)
                             .foregroundColor(.white)
+                            .frame(width: 50, height: 50)
                             .background(
                                 Circle()
                                     .fill(.red)
-                                    .frame(width: 50, height: 50)
                             )
+                            .shadow(radius: 4, y: 4)
                     }
-                    .frame(width: 50, height: 50)
-                    .shadow(radius: 4, y: 4)
                     
                     Spacer()
                     
@@ -58,14 +56,13 @@ struct MapView: View {
                             .resizable()
                             .frame(width: 17, height: 16)
                             .foregroundColor(.white)
+                            .frame(width: 50, height: 50)
                             .background(
                                 Circle()
                                     .fill(.red)
-                                    .frame(width: 50, height: 50)
                             )
+                            .shadow(radius: 4, y: 4)
                     }
-                    .frame(width: 50, height: 50)
-                    .shadow(radius: 4, y: 4)
                 }
                 .padding(.trailing, 16)
             }

--- a/Nav/MapView.swift
+++ b/Nav/MapView.swift
@@ -29,7 +29,7 @@ struct MapView: View {
                                 iconColor: .navWhite,
                                 iconWidth: 20,
                                 iconHeight: 20,
-                                buttonColor: .primary,
+                                buttonColor: .primaryRed,
                                 buttonSize: 50,
                                 shadowRadius: 4,
                                 shadowY: 4
@@ -43,7 +43,7 @@ struct MapView: View {
                                 iconColor: .navWhite,
                                 iconWidth: 20,
                                 iconHeight: 14.5,
-                                buttonColor: .primary,
+                                buttonColor: .primaryRed,
                                 buttonSize: 50,
                                 shadowRadius: 4,
                                 shadowY: 4
@@ -59,7 +59,7 @@ struct MapView: View {
                                 iconColor: .navWhite,
                                 iconWidth: 17,
                                 iconHeight: 16,
-                                buttonColor: .primary,
+                                buttonColor: .primaryRed,
                                 buttonSize: 50,
                                 shadowRadius: 4,
                                 shadowY: 4


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 메인 맵의 버튼 위치 등의 레이아웃을 추가하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- MapView 레이아웃 추가
- 자주 사용되는 버튼을 위한 `circleButton` Image Extension 추가

## ToDo 📆 (남은 작업)
- [ ] `+` 버튼 기능 추가

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/81027256/198880414-bf0337fc-86fc-4bda-8d0f-3e8e9ad4124b.gif" width="300">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 레이아웃을 위한 간단한 코드입니다. 가볍게 리뷰해주셔도 좋습니다.
- ~~색깔은 후에 한번에 수정할 예정입니다.~~ f02f494 로 색상 반영

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #3.
