### PR TITLE
feat: add scroll view

### DIFF
--- a/Nav.xcodeproj/project.pbxproj
+++ b/Nav.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		FD338916291799D800C4AB98 /* MockDatum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD338915291799D800C4AB98 /* MockDatum.swift */; };
 		FD338918291799E100C4AB98 /* Bundle+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD338917291799E100C4AB98 /* Bundle+Ext.swift */; };
 		FD33891A2917B81E00C4AB98 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3389192917B81E00C4AB98 /* ListView.swift */; };
+		FDFD7A5D292265DB001BE945 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFD7A5C292265DB001BE945 /* ImagePicker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,6 +40,7 @@
 		FD338915291799D800C4AB98 /* MockDatum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockDatum.swift; path = ../../../../Team_Nav/Nav/Model/MockDatum.swift; sourceTree = "<group>"; };
 		FD338917291799E100C4AB98 /* Bundle+Ext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Bundle+Ext.swift"; path = "../../../../Team_Nav/Nav/Extension/Bundle+Ext.swift"; sourceTree = "<group>"; };
 		FD3389192917B81E00C4AB98 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
+		FDFD7A5C292265DB001BE945 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 				262C17C5290E385E00450E54 /* Text+.swift */,
 				262C17BF290D06F700450E54 /* Color+.swift */,
 				26A1501029083A1400BC7355 /* Preview Content */,
+				FDFD7A5C292265DB001BE945 /* ImagePicker.swift */,
 			);
 			path = Nav;
 			sourceTree = "<group>";
@@ -209,6 +212,7 @@
 				26A1501929083B7B00BC7355 /* MapView.swift in Sources */,
 				FD338918291799E100C4AB98 /* Bundle+Ext.swift in Sources */,
 				FD33891A2917B81E00C4AB98 /* ListView.swift in Sources */,
+				FDFD7A5D292265DB001BE945 /* ImagePicker.swift in Sources */,
 				26A1500B29083A1300BC7355 /* NavApp.swift in Sources */,
 				262C17BE290CDF6900450E54 /* PinCreationView.swift in Sources */,
 			);

--- a/Nav/ImagePicker.swift
+++ b/Nav/ImagePicker.swift
@@ -1,0 +1,65 @@
+//
+//  ImagePicker.swift
+//  Nav
+//
+//  Created by shingyuuser on 2022/11/14.
+//
+
+import SwiftUI
+import PhotosUI
+
+@MainActor
+class ImagePicker: ObservableObject {
+    
+    @Published var image: Image?
+    @Published var images: [Image] = []
+    
+    @Published var imageSelection: PhotosPickerItem? {
+        didSet {
+            if let imageSelection {
+                Task {
+                    try await loadTransferable(from: imageSelection)
+                }
+            }
+        }
+    }
+    
+    @Published var imageSelections: [PhotosPickerItem] = [] {
+        didSet {
+            Task {
+                if !imageSelections.isEmpty {
+                    try await loadTransferable(from: imageSelections)
+                    imageSelections = []
+                }
+            }
+        }
+    }
+    
+    func loadTransferable(from imageSelections: [PhotosPickerItem]) async throws {
+        do {
+            for imageSelection in imageSelections {
+                if let data = try await imageSelection.loadTransferable(type: Data.self) {
+                    if let uiImage = UIImage(data: data) {
+                        self.images.append(Image(uiImage: uiImage))
+                    }
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
+    func loadTransferable(from imageSelection: PhotosPickerItem?) async throws {
+//        print(Image.transferRepresentation)
+        do {
+            if let data = try await imageSelection?.loadTransferable(type: Data.self) {
+                if let uiImage = UIImage(data: data) {
+                    self.image = Image(uiImage: uiImage)
+                }
+            }
+        } catch {
+            print(error.localizedDescription)
+            image = nil
+        }
+    }
+}

--- a/Nav/View/MapView.swift
+++ b/Nav/View/MapView.swift
@@ -59,7 +59,9 @@ struct MapView: View {
                         
                         Spacer()
                         
-                        Button(action: {}) {
+                        NavigationLink {
+                            PinCreationView()
+                        } label: {
                             Image(systemName: "plus")
                                 .circleButton(
                                     iconColor: .navWhite,

--- a/Nav/View/PinCreationView.swift
+++ b/Nav/View/PinCreationView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import PhotosUI
 
 struct PinCreationView: View {
     @State private var locationCategory: String = "음식"
@@ -14,6 +15,10 @@ struct PinCreationView: View {
     @State private var locationDescription: String = ""
     @State private var rating: [Bool] = [true, true, true, false, false]
     
+    @StateObject var imagePicker = ImagePicker()
+    let columns = [GridItem(.adaptive(minimum: 100))]
+    
+    
     var body: some View {
         NavigationView {
             VStack(alignment: .leading) {
@@ -21,9 +26,9 @@ struct PinCreationView: View {
                     Text("테마")
                         .subhead3()
                         .foregroundColor(.navBlack)
-
+                    
                     Spacer()
-
+                    
                     Button(action: {}) {
                         Text(locationCategory)
                             .body2()
@@ -37,10 +42,10 @@ struct PinCreationView: View {
                     Text("이름")
                         .subhead3()
                         .foregroundColor(.navBlack)
-
+                    
                     VStack {
                         TextField("추가할 장소의 이름을 입력해주세요.", text: $locationName)
-
+                        
                         Divider()
                     }
                     .padding(.leading, 16)
@@ -50,10 +55,9 @@ struct PinCreationView: View {
                     Text("주소")
                         .subhead3()
                         .foregroundColor(.navBlack)
-
+                    
                     VStack {
                         TextField("클릭해서 주소를 변경해주세요.", text: $locationAddress)
-
                         Divider()
                     }
                     .padding(.leading, 16)
@@ -64,71 +68,95 @@ struct PinCreationView: View {
                         .subhead3()
                         .foregroundColor(.navBlack)
                         .padding(.top, 20)
-                    
-                    Button(action: {}) {
-                        Image(systemName: "plus.circle.fill")
-                            .resizable()
-                            .frame(width: 30, height: 30)
-                            .tint(.primaryRed)
-                            .padding(40)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(Color.navGray)
-                            )
-                    }
-                }
-                
-                Group {
-                    Text("설명")
-                        .subhead3()
-                        .foregroundColor(.navBlack)
-
-                    TextEditor(text: $locationDescription)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color.navBlack, lineWidth: 1)
-                        )
-                }
-                
-                Group {
-                    Text("평점")
-                        .subhead3()
-                        .foregroundColor(.navBlack)
-                        .padding(.top, 20)
-
-                    // TODO: - 하단의 Spacer를 별점으로 변경
-                    
                     HStack {
-                        ForEach(rating, id: \.self) {
-                            Image(systemName: "star.fill")
-                                .resizable()
-                                .frame(width: 65, height: 65)
-                                .foregroundColor($0 ? .yellow : .navGray)
-                        }
+                            ScrollView(.horizontal, showsIndicators: false){
+                                LazyVGrid(columns: columns) {
+                                    ForEach(0..<imagePicker.images.count, id: \.self) { index in
+                                        imagePicker.images[index]
+                                            .resizable()
+                                            .scaledToFit()
+                                    }
+                                    
+                                    Button(action: {
+                                        print(imagePicker.images.count)
+                                    }) {
+                                        PhotosPicker(selection: $imagePicker.imageSelections,
+                                                     maxSelectionCount: 10,
+                                                     matching: .images,
+                                                     photoLibrary: .shared()) {
+                                            Image(systemName: "plus.circle.fill")
+                                                .resizable()
+                                                .frame(width: 30, height: 30)
+                                                .tint(.primaryRed)
+                                        }
+                                    }
+                                    .frame(width: 100, height: 100)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 8)
+                                            .fill(Color.navGray)
+                                    )
+                                }
+                            }
+                            .onAppear {
+                                        UIScrollView.appearance().bounces = false
+                                    }
+                                    .onDisappear {
+                                        UIScrollView.appearance().bounces = true
+                                    }
                     }
-                    .padding(.bottom, 20)
-                }
-                
-                Button(action: {}) {
-                    Text("확인")
-                        .headline()
-                        .foregroundColor(.navWhite)
-                        .frame(maxWidth: .infinity, maxHeight: 50)
-                        .background(
-                            RoundedRectangle(cornerRadius: 16)
-                                .fill(Color.primaryRed)
-                        )
                 }
             }
-            .padding(16)
-            .navigationTitle("핀 추가")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: {}) {
-                        Image(systemName: "xmark")
-                            .foregroundColor(.navBlack)
+            
+            Group {
+                Text("설명")
+                    .subhead3()
+                    .foregroundColor(.navBlack)
+                
+                TextEditor(text: $locationDescription)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.navBlack, lineWidth: 1)
+                    )
+            }
+            
+            Group {
+                Text("평점")
+                    .subhead3()
+                    .foregroundColor(.navBlack)
+                    .padding(.top, 20)
+                
+                // TODO: - 하단의 Spacer를 별점으로 변경
+                
+                HStack {
+                    ForEach(rating, id: \.self) {
+                        Image(systemName: "star.fill")
+                            .resizable()
+                            .frame(width: 65, height: 65)
+                            .foregroundColor($0 ? .yellow : .navGray)
                     }
+                }
+                .padding(.bottom, 20)
+            }
+            
+            Button(action: {}) {
+                Text("확인")
+                    .headline()
+                    .foregroundColor(.navWhite)
+                    .frame(maxWidth: .infinity, maxHeight: 50)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(Color.primaryRed)
+                    )
+            }
+        }
+        .padding(16)
+        .navigationTitle("핀 추가")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: {}) {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.navBlack)
                 }
             }
         }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
이미지 추가 관련 스크롤뷰 구현했습니다

## Key Changes 🔥 (주요 구현/변경 사항)
이미지 추가 시 추가 버튼 이동

## ToDo 📆 (남은 작업)
- 이미지 보다 더 많이 스크롤되는 것 수정

## ScreenShot 📷 (참고 사진)
<img width="337" alt="스크린샷 2022-11-17 오전 1 21 40" src="https://user-images.githubusercontent.com/82097725/202235790-f5220bfd-27f2-4d8c-b242-c82980abbd5f.png">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
스크롤이 버튼 이후로는 스크롤 되지 않게 막는 방법 알려주실 분 구합니다

## Reference 🔗
지난 번에 올린 영상보고 따라 함.

## Close Issues 🔒 (닫을 Issue)
Close #No.
